### PR TITLE
"build:server" now targets Node

### DIFF
--- a/webpack/server.prod.js
+++ b/webpack/server.prod.js
@@ -9,6 +9,7 @@ module.exports = {
   entry: [
     './routes/index.js',
   ],
+  target: 'node',
   output: {
     path: path.join(__dirname, '../server/bin'),
     filename: './server.js',


### PR DESCRIPTION
This change allows `socket.io` to work on the server. 
WebPack targets `web` by default, disabling the `http.Server` method, which `socket.io` requires.